### PR TITLE
feat/sort-by-talks-count-filter

### DIFF
--- a/src/components/FilterPopover/memberFilter.tsx
+++ b/src/components/FilterPopover/memberFilter.tsx
@@ -6,9 +6,16 @@ import { MemberStatus, MemberStatusLabels } from "@/types/types";
 const ALL_OPTION = "all";
 const ALL_LABEL = "All";
 
+const SORT_OPTIONS = [
+  { value: "", label: "Default" },
+  { value: "talks_desc", label: "Most Talks" },
+];
+
 interface MemberFilterProps {
   onStatusChange: (status: string[]) => void;
+  onSortChange: (sortBy: string) => void;
   currentStatus: string;
+  currentSortBy: string;
   availableStatuses?: MemberStatus[];
   defaultStatuses?: MemberStatus[];
   isOnboarding?: boolean;
@@ -16,7 +23,9 @@ interface MemberFilterProps {
 
 export default function MemberFilter({
   onStatusChange,
+  onSortChange,
   currentStatus,
+  currentSortBy,
   availableStatuses = Object.values(MemberStatus), // Default: all statuses
   defaultStatuses = [MemberStatus.Active, MemberStatus.SociallyActive], // Default: active members
   isOnboarding = false,
@@ -34,6 +43,7 @@ export default function MemberFilter({
   const [selectedStatus, setSelectedStatus] = useState<string>(
     currentStatus === "all" ? ALL_OPTION : currentStatus,
   );
+  const [selectedSort, setSelectedSort] = useState<string>(currentSortBy);
 
   const handleStatusSelect = (value: string) => {
     setSelectedStatus(value);
@@ -44,12 +54,15 @@ export default function MemberFilter({
       selectedStatus === ALL_OPTION ? availableStatuses : [selectedStatus];
 
     onStatusChange(statusesToSend);
+    onSortChange(selectedSort);
     filterPopoverRef.current?.closePopover();
   };
 
   const handleClear = () => {
     setSelectedStatus(ALL_OPTION);
+    setSelectedSort("");
     onStatusChange(defaultStatuses);
+    onSortChange("");
     filterPopoverRef.current?.closePopover();
   };
 
@@ -65,6 +78,12 @@ export default function MemberFilter({
           options={selectorOptions}
           value={selectedStatus}
           onChange={handleStatusSelect}
+        />
+        <Selector
+          label="Sort By"
+          options={SORT_OPTIONS}
+          value={selectedSort}
+          onChange={setSelectedSort}
         />
         <div className="buttons flex flex-row gap-2">
           <button

--- a/src/components/FilterPopover/memberFilter.tsx
+++ b/src/components/FilterPopover/memberFilter.tsx
@@ -79,12 +79,14 @@ export default function MemberFilter({
           value={selectedStatus}
           onChange={handleStatusSelect}
         />
-        <Selector
-          label="Sort By"
-          options={SORT_OPTIONS}
-          value={selectedSort}
-          onChange={setSelectedSort}
-        />
+        {!isOnboarding && (
+          <Selector
+            label="Sort By"
+            options={SORT_OPTIONS}
+            value={selectedSort}
+            onChange={setSelectedSort}
+          />
+        )}
         <div className="buttons flex flex-row gap-2">
           <button
             onClick={handleApplyFilter}

--- a/src/pages/members.tsx
+++ b/src/pages/members.tsx
@@ -26,6 +26,7 @@ export default function Members() {
   const { token } = useAuthStore();
   const [paginationNumber, setPaginationNumber] = useState(1);
   const [statusFilter, setStatusFilter] = useState<string[]>(DEFAULT_STATUSES);
+  const [sortBy, setSortBy] = useState<string>("");
 
   const [searchResults, setSearchResults] = useState<Member[]>([]);
   const [isSearching, setIsSearching] = useState(false);
@@ -42,6 +43,10 @@ export default function Members() {
     statusFilter.forEach((status) => {
       queryParams.append("status[]", status);
     });
+
+    if (sortBy) {
+      queryParams.append("sort_by", sortBy);
+    }
 
     return [
       `${apiUrl}/api/v1/members/filtered?${queryParams.toString()}`,
@@ -68,7 +73,7 @@ export default function Members() {
   // Reset pagination when filters change
   useEffect(() => {
     setPaginationNumber(1);
-  }, [statusFilter]);
+  }, [statusFilter, sortBy]);
 
   const currentStatusLabels = statusFilter.map((status) =>
     getStatusLabel(status),
@@ -76,6 +81,10 @@ export default function Members() {
 
   const handleStatusChange = (statuses: string[]) => {
     setStatusFilter(statuses);
+  };
+
+  const handleSortChange = (newSortBy: string) => {
+    setSortBy(newSortBy);
   };
 
   const handleSearchResults = (results: Member[], searching: boolean) => {
@@ -111,7 +120,9 @@ export default function Members() {
         </div>
         <MemberFilter
           onStatusChange={handleStatusChange}
+          onSortChange={handleSortChange}
           currentStatus={getCurrentSingleStatus()}
+          currentSortBy={sortBy}
           defaultStatuses={DEFAULT_STATUSES}
         />
       </div>

--- a/src/pages/onboarding.tsx
+++ b/src/pages/onboarding.tsx
@@ -174,7 +174,9 @@ export default function Onboarding() {
                     Status
                     <MemberFilter
                       onStatusChange={handleStatusChange}
+                      onSortChange={() => {}}
                       currentStatus={getCurrentSingleStatus()}
+                      currentSortBy=""
                       availableStatuses={ONBOARDING_STATUSES}
                       defaultStatuses={ONBOARDING_STATUSES}
                       isOnboarding={true}


### PR DESCRIPTION
## Description

Provide a clear and concise description of what this PR does

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Configuration change
- [ ] Dependency update

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
allows sorting filter to order members by talks count in descending order

## Changes Made

<!-- List the specific changes made in this PR -->
Added sort by filter for
- default option (by member with most recent created talk)
- most talk option (sort member by their talks count in descending order, most talks -> least talks)

## Screenshots (if applicable)

<!-- Add screenshots to demonstrate visual changes -->

| Before | After |
| ------ | ----- |
|    <img width="252" height="185" alt="image" src="https://github.com/user-attachments/assets/12589b7b-4e28-4c6b-a9e9-e7d49d8f8c51" /> |  <img width="272" height="272" alt="image" src="https://github.com/user-attachments/assets/68c20337-688e-4245-ad94-a9e5c0a464e8" /> |

## Additional Notes

<!-- Any additional information that reviewers should know -->
PR for backend https://github.com/hackerspacemmu/hacktrackmmu/pull/71

## Reviewer Guidelines

<!-- Specific areas where you'd like reviewer focus -->
